### PR TITLE
Fix the lack of argument's specification in documentations about getrow.

### DIFF
--- a/doc/getrow.md
+++ b/doc/getrow.md
@@ -3,7 +3,7 @@
        getrow - read table-formed data from stdin and get a row in it
 
 ## SYNOPSIS
-       getrow
+       getrow index
 
 ## DESCRIPTION
        getrow  reads  table-formed  data from stdin and get a row in it. The

--- a/man/getrow.1
+++ b/man/getrow.1
@@ -4,7 +4,7 @@ getrow \- read table-formed data from stdin and get a row in it
 
 .SH SYNOPSIS
 .B getrow
-.Iindex
+.I index
 
 .SH DESCRIPTION
 .I getrow


### PR DESCRIPTION
 Both in doc/getrow.md and man/getrow.1