### PR TITLE
Fix .cmd default directory.

### DIFF
--- a/mkexe
+++ b/mkexe
@@ -48,7 +48,7 @@ case $ext in
     js  ) not_support ;;
     cmd ) sheb=/bin/bash
           tmp_dir=/var/tmp/mkexe/sh
-          dir=/usr/local/share/bin
+          dir=/usr/local/bin
           filename="`echo $filename | sed -e 's/\.[^\.]*$//g'`" ;;
     *   ) custom_ext ;;
 esac


### PR DESCRIPTION
from /usr/local/share/bin to /usr/local/bin. /usr/local/share/bin does not exist at default, and permission error occurred when system tries to create the directory.